### PR TITLE
Avoid starting eval runs when parent run active

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -56,6 +56,7 @@ class MlflowCallback(BaseCallback):
         # call_id: (key, step)
         self._call_id_to_metric_key: dict[str, tuple[str, int]] = {}
         self._evaluation_counter = defaultdict(int)
+        self._eval_runs_started: set[str] = set()
 
     def set_dependencies_schema(self, dependencies_schema: dict[str, Any]):
         if self._dependencies_schema:
@@ -234,6 +235,7 @@ class MlflowCallback(BaseCallback):
         if callback_metadata := inputs.get("callback_metadata"):
             if "metric_key" in callback_metadata:
                 key = callback_metadata["metric_key"]
+        started_run = False
         if self.optimizer_stack_level > 0:
             with _lock:
                 # we may want to include optimizer_stack_level in the key
@@ -242,8 +244,13 @@ class MlflowCallback(BaseCallback):
                 self._evaluation_counter[key] += 1
             self._call_id_to_metric_key[call_id] = (key, step)
             mlflow.start_run(run_name=f"{key}_{step}", nested=True)
-        else:
+            started_run = True
+        elif mlflow.active_run() is None:
             mlflow.start_run(run_name=key, nested=True)
+            started_run = True
+
+        if started_run:
+            self._eval_runs_started.add(call_id)
         if program := inputs.get("program"):
             save_dspy_module_state(program, "model.json")
             log_dspy_module_params(program)
@@ -261,8 +268,13 @@ class MlflowCallback(BaseCallback):
         """
         if not get_autologging_config(FLAVOR_NAME, "log_evals"):
             return
+        run_started = call_id in self._eval_runs_started
         if exception:
-            mlflow.end_run(status=RunStatus.to_string(RunStatus.FAILED))
+            if run_started:
+                mlflow.end_run(status=RunStatus.to_string(RunStatus.FAILED))
+                self._eval_runs_started.discard(call_id)
+            if self.optimizer_stack_level > 0:
+                self._call_id_to_metric_key.pop(call_id, None)
             return
         score = None
         if isinstance(outputs, float):
@@ -278,7 +290,9 @@ class MlflowCallback(BaseCallback):
         if score is not None:
             mlflow.log_metric("eval", score)
 
-        mlflow.end_run()
+        if run_started:
+            mlflow.end_run()
+            self._eval_runs_started.discard(call_id)
         # Log the evaluation score to the parent run if called inside optimization
         if self.optimizer_stack_level > 0 and mlflow.active_run() is not None:
             if call_id not in self._call_id_to_metric_key:
@@ -294,6 +308,7 @@ class MlflowCallback(BaseCallback):
     def reset(self):
         self._call_id_to_metric_key: dict[str, tuple[str, int]] = {}
         self._evaluation_counter = defaultdict(int)
+        self._eval_runs_started = set()
 
     def _start_span(
         self,

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -760,32 +760,26 @@ def test_autolog_nested_evals():
     evaluator = Evaluate(devset=examples, metric=answer_exact_match)
 
     mlflow.dspy.autolog(log_evals=True)
-    with mlflow.start_run() as run:
+    with mlflow.start_run() as active_run:
         evaluator(program, devset=examples[:1])
         evaluator(program, devset=examples[1:])
 
-    # children runs
     client = MlflowClient()
+    run = client.get_run(active_run.info.run_id)
+    assert run.data.metrics == {"eval": 0.0}
+
+    artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
+    assert "model.json" in artifacts
+
+    metric_history = client.get_metric_history(run.info.run_id, "eval")
+    assert [metric.value for metric in metric_history] == [100.0, 0.0]
+
     child_runs = client.search_runs(
         run.info.experiment_id,
         filter_string=f"tags.mlflow.parentRunId = '{run.info.run_id}'",
         order_by=["attributes.start_time ASC"],
     )
-    assert len(child_runs) == 2
-    for i, run in enumerate(child_runs):
-        if i == 0:
-            assert run.data.metrics == {"eval": 100.0}
-        else:
-            assert run.data.metrics == {"eval": 0}
-        assert run.data.params == {
-            "Predict.signature.fields.0.description": "${question}",
-            "Predict.signature.fields.0.prefix": "Question:",
-            "Predict.signature.fields.1.description": "${answer}",
-            "Predict.signature.fields.1.prefix": "Answer:",
-            "Predict.signature.instructions": "Given the fields `question`, produce the fields `answer`.",  # noqa: E501
-        }
-        artifacts = (x.path for x in client.list_artifacts(run.info.run_id))
-        assert "model.json" in artifacts
+    assert len(child_runs) == 0
 
 
 @skip_when_testing_trace_sdk


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/1?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/1/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/1/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/1/merge
```

</p>
</details>

## Summary
- avoid creating nested MLflow runs from the DSPy evaluate callback when a parent run is already active outside of compile execution
- track evaluate calls that start runs so that the callback only ends runs it created and clears state on failures
- update the nested evaluate autologging test to validate metrics are logged on the parent run without spawning child runs

## Testing
- pytest tests/dspy/test_dspy_autolog.py::test_autolog_log_evals tests/dspy/test_dspy_autolog.py::test_autolog_nested_evals tests/dspy/test_dspy_autolog.py::test_autolog_log_compile_with_evals -q *(fails: ModuleNotFoundError: No module named 'dspy')*


------
https://chatgpt.com/codex/tasks/task_e_68ce44d6c758832ab7141a9ffe9954f5