### PR TITLE
Fix usage aggregation to avoid ancestor duplication

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -231,15 +231,8 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
         else:
             roots.append(span)
 
-    visited: set[str] = set()
-
     def dfs(span: LiveSpan, ancestor_has_usage: bool) -> None:
         nonlocal input_tokens, output_tokens, total_tokens, has_usage_data
-
-        if span.span_id in visited:
-            return
-
-        visited.add(span.span_id)
 
         usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
         span_has_usage = usage is not None

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -257,11 +257,6 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
     for root in roots:
         dfs(root, False)
 
-    # Handle spans that were not reachable due to missing parents or cycles.
-    for span in spans:
-        if span.span_id not in visited:
-            dfs(span, False)
-
     # If none of the spans have token usage data, we shouldn't log token usage metadata.
     if not has_usage_data:
         return None

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -5,7 +5,7 @@ import inspect
 import json
 import logging
 import uuid
-from collections import Counter
+from collections import Counter, defaultdict
 from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
 from functools import lru_cache
@@ -221,23 +221,46 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
     has_usage_data = False
 
     span_id_to_spans = {span.span_id: span for span in spans}
-    for span in spans:
-        # Get usage attribute from span
-        if usage := span.get_attribute(SpanAttributeKey.CHAT_USAGE):
-            # If the parent span is also LLM/Chat span and has the token usage data,
-            # it tracks the same usage data by multiple flavors e.g. LangChain ChatOpenAI
-            # and OpenAI tracing. We should avoid double counting the usage data.
-            if (
-                span.parent_id
-                and (parent_span := span_id_to_spans.get(span.parent_id))
-                and parent_span.get_attribute(SpanAttributeKey.CHAT_USAGE)
-            ):
-                continue
+    children_map: defaultdict[str, list[LiveSpan]] = defaultdict(list)
+    roots: list[LiveSpan] = []
 
+    for span in spans:
+        parent_id = span.parent_id
+        if parent_id and parent_id in span_id_to_spans:
+            children_map[parent_id].append(span)
+        else:
+            roots.append(span)
+
+    visited: set[str] = set()
+
+    def dfs(span: LiveSpan, ancestor_has_usage: bool) -> None:
+        nonlocal input_tokens, output_tokens, total_tokens, has_usage_data
+
+        if span.span_id in visited:
+            return
+
+        visited.add(span.span_id)
+
+        usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
+        span_has_usage = usage is not None
+
+        if span_has_usage and not ancestor_has_usage:
             input_tokens += usage.get(TokenUsageKey.INPUT_TOKENS, 0)
             output_tokens += usage.get(TokenUsageKey.OUTPUT_TOKENS, 0)
             total_tokens += usage.get(TokenUsageKey.TOTAL_TOKENS, 0)
             has_usage_data = True
+
+        next_ancestor_has_usage = ancestor_has_usage or span_has_usage
+        for child in children_map.get(span.span_id, []):
+            dfs(child, next_ancestor_has_usage)
+
+    for root in roots:
+        dfs(root, False)
+
+    # Handle spans that were not reachable due to missing parents or cycles.
+    for span in spans:
+        if span.span_id not in visited:
+            dfs(span, False)
 
     # If none of the spans have token usage data, we shouldn't log token usage metadata.
     if not has_usage_data:

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -108,7 +108,9 @@ def test_aggregate_usage_from_spans_skips_descendant_usage():
             create_mock_otel_span("trace_id", span_id=3, name="grandchild", parent_id=2),
             trace_id="tr-123",
         ),
-        LiveSpan(create_mock_otel_span("trace_id", span_id=4, name="independent"), trace_id="tr-123"),
+        LiveSpan(
+            create_mock_otel_span("trace_id", span_id=4, name="independent"), trace_id="tr-123"
+        ),
     ]
 
     spans[0].set_attribute(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/2?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/2/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/2/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/2/merge
```

</p>
</details>

## Summary
- traverse the span hierarchy with DFS when aggregating usage to prevent double counting when ancestors already report usage
- add a regression test covering spans with usage on ancestors and independent branches

## Testing
- pytest tests/tracing/utils/test_utils.py::test_aggregate_usage_from_spans tests/tracing/utils/test_utils.py::test_aggregate_usage_from_spans_skips_descendant_usage

------
https://chatgpt.com/codex/tasks/task_e_68d3cd1ec728832a9a705dd9918f53eb